### PR TITLE
fix: sddm: rename theme.conf.user to theme.conf

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -7,7 +7,7 @@ case $1 in
     remove)
         conflicts="
         /etc/skel/.face
-        /usr/share/sddm/themes/breeze/theme.conf.user
+        /usr/share/sddm/themes/breeze/theme.conf
         "
         for i in $conflicts
         do

--- a/debian/preinst
+++ b/debian/preinst
@@ -5,7 +5,7 @@ case $1 in
     install|upgrade)
         conflicts="
         /etc/skel/.face
-        /usr/share/sddm/themes/breeze/theme.conf.user
+        /usr/share/sddm/themes/breeze/theme.conf
         "
         for i in $conflicts
         do

--- a/src/usr/share/sddm/themes/breeze/theme.conf
+++ b/src/usr/share/sddm/themes/breeze/theme.conf
@@ -1,5 +1,8 @@
 [General]
+showlogo=hidden
 logo=/usr/share/images/radxa-logos/logo-256.png
 type=image
-color=#74BC1F
+color=#1d99f3
+fontSize=10
 background=/usr/share/desktop-base/radxa-theme/login/background.svg
+needsFullUserModel=false


### PR DESCRIPTION
To avoid the wallpaper being deleted
when switching themes or backgrounds in KDE/sddm-kcm: https://github.com/KDE/sddm-kcm/blob/d552a9017a175a096974d54a065367af47a197f9/sddmauthhelper.cpp#L319-L335

fixes: https://github.com/RadxaOS-SDK/rsdk/pull/91#issuecomment-3266653685